### PR TITLE
Add Optional Attr-Map Param to defunc Macro

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -8,6 +8,7 @@
   :pedantic? :abort
 
   :dependencies [[org.clojars.akiel/datomic-spec "0.1-alpha19"]
-                 [org.clojure/clojure "1.9.0"]]
+                 [org.clojure/clojure "1.9.0"]
+                 [org.clojure/core.specs.alpha "0.2.36"]]
 
   :profiles {:dev {:dependencies [[com.datomic/datomic-free "0.9.5656"]]}})

--- a/src/datomic_tools/schema.clj
+++ b/src/datomic_tools/schema.clj
@@ -1,5 +1,6 @@
 (ns datomic-tools.schema
   (:require
+    [clojure.core.specs.alpha :as core-specs]
     [clojure.spec.alpha :as s]
     [datomic.api :as d]
     [datomic-spec.core :as ds]))
@@ -75,8 +76,14 @@
   (->> (assoc schema :db/ident name)
        (swap! fn-reg assoc name)))
 
+(s/def ::requires
+  (s/spec
+    (s/* ::core-specs/libspec)))
+
 (def defunc-args
-  (s/cat :name symbol :doc-string (s/? string?)
+  (s/cat :name simple-symbol?
+         :doc-string (s/? string?)
+         :attr-map (s/? (s/keys :opt-un [::requires]))
          :params (s/coll-of simple-symbol? :kind vector?)
          :body (s/+ any?)))
 
@@ -85,14 +92,14 @@
 
 (defmacro defunc
   "Defines a database function."
-  {:arglists '([name doc-string? [params*] body])}
+  {:arglists '([name doc-string? attr-map? [params*] body])}
   [& args]
-  (let [{:keys [name doc-string params body]} (s/conform defunc-args args)
+  (let [{:keys [name doc-string attr-map params body]} (s/conform defunc-args args)
         name (keyword name)
+        {:keys [requires]} attr-map
         schema (cond-> {:db/fn `(d/function '{:lang "clojure" :params ~params
-                                              :requires [[clojure.core.reducers]]
-                                              :code (do ~@body)
-                                              })}
+                                             :requires ~(s/unform ::requires requires)
+                                             :code (do ~@body)})}
                  doc-string (assoc :db/doc doc-string))]
     `(reg-fn! ~name ~schema)))
 


### PR DESCRIPTION
Adds attr-map as an optional parameter to the
defunc macro to allow macro users to pass
namespaces that shall be loaded by the
transactor.